### PR TITLE
Remove outdated HTML keyword

### DIFF
--- a/sphinx/themes/basic/layout.html
+++ b/sphinx/themes/basic/layout.html
@@ -137,7 +137,7 @@
           href="{{ pathto('_static/opensearch.xml', 1) }}"/>
     {%- endif %}
     {%- if favicon_url %}
-    <link rel="shortcut icon" href="{{ favicon_url|e }}"/>
+    <link rel="icon" href="{{ favicon_url|e }}"/>
     {%- endif %}
     {%- endif %}
 {%- block linktags %}

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -1370,7 +1370,7 @@ def test_html_remote_logo(app, status, warning):
 
     result = (app.outdir / 'index.html').read_text(encoding='utf8')
     assert ('<img class="logo" src="https://www.python.org/static/img/python-logo.png" alt="Logo"/>' in result)
-    assert ('<link rel="shortcut icon" href="https://www.python.org/static/favicon.ico"/>' in result)
+    assert ('<link rel="icon" href="https://www.python.org/static/favicon.ico"/>' in result)
     assert not (app.outdir / 'python-logo.png').exists()
 
 


### PR DESCRIPTION
The keyword `shortcut` was used by historic browsers. It is not required anymore by the HTML5 specification.

Subject: <short purpose of this pull request>

### Feature or Bugfix
<!-- please choose -->
- Feature
- Bugfix
- Refactoring

### Purpose
- <long purpose of this pull request>
- <Environment if this PR depends on>

### Detail
- <feature1 or bug1>
- <feature2 or bug2>

### Relates
- <URL or Ticket>

